### PR TITLE
Category route fix

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,6 @@ DATABASE_URL = os.getenv('DATABASE_URL_DEV')
 if env == 'production':
     DATABASE_URL = os.getenv('DATABASE_URL_PROD')
 
-print('DATABASE_URL:', DATABASE_URL)
 engine = create_engine(DATABASE_URL, pool_size=30, max_overflow=20)
 Base = declarative_base()
 

--- a/routes/category/category.py
+++ b/routes/category/category.py
@@ -290,10 +290,10 @@ def delete_category(category_id):
                 response["error"] = f"No category found with ID: {category_id}"
                 return jsonify(response), 404
 
-            # Delete associated icon from S3
-            if category.icon:
-                icon_filename = category.icon
-                image_processor.delete_from_s3(S3_BUCKET_ICONS, icon_filename)
+            # # Delete associated icon from S3
+            # if category.icon:
+            #     icon_filename = category.icon
+            #     image_processor.delete_from_s3(S3_BUCKET_ICONS, icon_filename)
 
             # Delete the category from the database
             session.delete(category)

--- a/routes/category/category.py
+++ b/routes/category/category.py
@@ -291,9 +291,9 @@ def delete_category(category_id):
                 return jsonify(response), 404
 
             # # Delete associated icon from S3
-            # if category.icon:
-            #     icon_filename = category.icon
-            #     image_processor.delete_from_s3(S3_BUCKET_ICONS, icon_filename)
+            if category.icon:
+                icon_filename = category.icon
+                image_processor.delete_from_s3(S3_BUCKET_ICONS, icon_filename)
 
             # Delete the category from the database
             session.delete(category)


### PR DESCRIPTION
# Database Schema Update: Article Table Alignment

## Changes Made
- Renamed column 'id' to 'article_id' in the Article table to match SQLAlchemy model structure
- This fixes the database error where SQLAlchemy was looking for 'article_id' but found 'id' instead

## Technical Details
- Updated database table schema to align with the SQLAlchemy model definition
- The Article model expects 'article_id' as primary key, but the database had it as 'id'
- The change maintains all properties (PRIMARY KEY, SERIAL, etc.) while just updating the column name
- Schema alignment prevents the `UndefinedColumn` error in article-related routes
